### PR TITLE
Release v1.5.4

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15 #[self-hosted, macOS]
+    runs-on: macos-26 #[self-hosted, macOS]
 
     steps:
     - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 16.3
+        xcode-version: 26.0
 
     - uses: irgaly/xcode-cache@v1
       with:
@@ -32,5 +32,5 @@ jobs:
       run: |
         xcodebuild test \
           -scheme 'OctopusSdkSwift-Package' \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+          -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
           CODE_SIGNING_ALLOWED='NO'

--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.5.3
+APP_VERSION = 1.5.4
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/Sample/OctopusSample/UI/Scenarios/BridgeToClientObject/BridgeToClientObjectView.swift
+++ b/Sample/OctopusSample/UI/Scenarios/BridgeToClientObject/BridgeToClientObjectView.swift
@@ -85,6 +85,7 @@ private struct RecipeScreen: View {
                         }
                         .buttonStyle(.plain)
                 )
+                .presentationBackground(Color(.systemBackground))
         }
     }
 }

--- a/Sample/OctopusSample/UI/Scenarios/SSO/UserRelatedViews/AppEditUserScreen.swift
+++ b/Sample/OctopusSample/UI/Scenarios/SSO/UserRelatedViews/AppEditUserScreen.swift
@@ -43,6 +43,7 @@ struct AppEditUserScreen: View {
                 bio = appUser?.bio ?? ""
                 picture = appUser?.picture
             }
+            .presentationBackground(Color(.systemBackground))
         }
     }
 }

--- a/Sample/OctopusSample/UI/Scenarios/SSO/UserRelatedViews/AppLoginScreen.swift
+++ b/Sample/OctopusSample/UI/Scenarios/SSO/UserRelatedViews/AppLoginScreen.swift
@@ -76,6 +76,7 @@ struct AppLoginScreen: View {
                     }
                 }
             }
+            .presentationBackground(Color(.systemBackground))
         }
     }
 }

--- a/Sample/OctopusSample/UI/SwiftUIUtils/View+PresentationBackground.swift
+++ b/Sample/OctopusSample/UI/SwiftUIUtils/View+PresentationBackground.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © 2025 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+    /// Apply a safe area inset to this view.
+    /// When the keyboard is displayed, remove the inset
+    /// - Parameter bottomSafeAreaInset: the bottom safe area to set
+    @_disfavoredOverload
+    func presentationBackground(_ color: Color) -> some View {
+        self
+            .modify {
+                if #available(iOS 16.4, *) {
+                    $0.presentationBackground(color)
+                } else {
+                    $0
+                }
+            }
+    }
+}

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.5.3'
+  VERSION = '1.5.4'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.5.3"
+public let version: String = "1.5.4"

--- a/Sources/OctopusUI/Atoms/BackButton.swift
+++ b/Sources/OctopusUI/Atoms/BackButton.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright © 2024 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import Octopus
+
+struct BackButton: View {
+    @Environment(\.octopusTheme) private var theme
+
+    let action: () -> Void
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            Button(action: action) {
+                Image(systemName: "chevron.left")
+                    .font(theme.fonts.navBarItem.weight(.semibold))
+                    .contentShape(Rectangle())
+            }
+        } else {
+            Button(action: action) {
+                Image(systemName: "chevron.left")
+                    .font(theme.fonts.navBarItem.weight(.semibold))
+                    .contentShape(Rectangle())
+                    .padding(.trailing, 40)
+            }
+            .padding(.leading, -8)
+        }
+    }
+}
+
+#Preview {
+    CreateButton(kind: .post, actionTapped: {})
+}

--- a/Sources/OctopusUI/Comments/Detail/CommentDetailView.swift
+++ b/Sources/OctopusUI/Comments/Detail/CommentDetailView.swift
@@ -204,15 +204,7 @@ struct CommentDetailView: View {
     @ViewBuilder
     private var leadingBarItem: some View {
         if replyHasChanges {
-            Button(action: {
-                showChangesWillBeLostAlert = true
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(theme.fonts.navBarItem.weight(.semibold))
-                    .contentShape(Rectangle())
-                    .padding(.trailing, 40)
-            }
-            .padding(.leading, -8)
+            BackButton(action: { showChangesWillBeLostAlert = true })
         } else {
             EmptyView()
         }

--- a/Sources/OctopusUI/Connection/MagicLinkView.swift
+++ b/Sources/OctopusUI/Connection/MagicLinkView.swift
@@ -42,6 +42,7 @@ struct MagicLinkView: View {
                     EmptyView()
                 }.hidden()
             }
+            .presentationBackground(Color(.systemBackground))
             .compatAlert(
                 "Common.Error",
                 isPresented: $displayMagicLinkConfirmationError,

--- a/Sources/OctopusUI/OctopusHomeScreen.swift
+++ b/Sources/OctopusUI/OctopusHomeScreen.swift
@@ -111,6 +111,7 @@ public struct OctopusHomeScreen: View {
                     }
                 }
                 .insetableMainNavigationView(bottomSafeAreaInset: bottomSafeAreaInset)
+                .presentationBackground(Color(.systemBackground))
             } else {
                 RootFeedsView(octopus: octopus, mainFlowPath: mainFlowPath, navBarLeadingItem: navBarLeadingItem,
                               navBarPrimaryColor: navBarPrimaryColor)
@@ -123,6 +124,7 @@ public struct OctopusHomeScreen: View {
                 .safeAreaInsetCompat(edge: .bottom) {
                     Spacer().frame(height: bottomSafeAreaInset)
                 }
+                .presentationBackground(Color(.systemBackground))
             }
             } else {
                 UnsupportedOSVersionView()

--- a/Sources/OctopusUI/Posts/Create/CreatePostView.swift
+++ b/Sources/OctopusUI/Posts/Create/CreatePostView.swift
@@ -16,7 +16,7 @@ struct CreatePostView: View {
     @State private var showTopicPicker = false
     @State private var displayError = false
     @State private var displayableError: DisplayableString?
-    @State private var topicPickerDetentHeight: CGFloat = 0
+    @State private var topicPickerDetentHeight: CGFloat = 80
     @State private var showChangesWillBeLostAlert = false
     @State private var height: CGFloat = 0
 
@@ -36,8 +36,10 @@ struct CreatePostView: View {
                         selectedTopic: viewModel.selectedTopic,
                         showTopicPicker: $showTopicPicker,
                         createPoll: viewModel.createPoll)
+            .presentationBackground(Color(.systemBackground))
             .navigationBarTitle(Text("Post.Create.Title", bundle: .module), displayMode: .inline)
-            .navigationBarItems(leading: cancelButton, trailing: postButton)
+            .toolbar(leading: cancelButton, trailing: postButton,
+                     trailingSharedBackgroundVisibility: .hidden)
             .sheet(isPresented: $showTopicPicker) {
                 if #available(iOS 16.0, *) {
                     TopicPicker(topics: viewModel.topics, selectedTopic: $viewModel.selectedTopic)
@@ -120,8 +122,8 @@ struct CreatePostView: View {
             }
         }) {
             Image(systemName: "xmark")
-                .resizable()
                 .font(theme.fonts.navBarItem)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Sources/OctopusUI/Posts/Detail/PostDetailView.swift
+++ b/Sources/OctopusUI/Posts/Detail/PostDetailView.swift
@@ -229,15 +229,7 @@ struct PostDetailView: View {
             Color.white.opacity(0.0001)
         } else
         if commentHasChanges {
-            Button(action: {
-                showChangesWillBeLostAlert = true
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(theme.fonts.navBarItem.weight(.semibold))
-                    .contentShape(Rectangle())
-                    .padding(.trailing, 40)
-            }
-            .padding(.leading, -8)
+            BackButton(action: { showChangesWillBeLostAlert = true })
         } else {
             EmptyView()
         }

--- a/Sources/OctopusUI/Profile/CurrentUser/Edit/EditProfileView.swift
+++ b/Sources/OctopusUI/Profile/CurrentUser/Edit/EditProfileView.swift
@@ -38,7 +38,8 @@ struct EditProfileView: View {
         )
         .navigationBarBackButtonHidden(viewModel.hasChanges)
         .navigationBarTitle(Text("Common.Edit", bundle: .module), displayMode: .inline)
-        .navigationBarItems(leading: leadingBarItem, trailing: trailingBarItem)
+        .toolbar(leading: leadingBarItem, trailing: trailingBarItem,
+                 trailingSharedBackgroundVisibility: .hidden)
         .compatAlert(
             "Common.Error",
             isPresented: $displayError,
@@ -103,15 +104,7 @@ struct EditProfileView: View {
     @ViewBuilder
     private var leadingBarItem: some View {
         if viewModel.hasChanges {
-            Button(action: {
-                showChangesWillBeLostAlert = true
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(theme.fonts.navBarItem.weight(.semibold))
-                    .contentShape(Rectangle())
-                    .padding(.trailing, 40)
-            }
-            .padding(.leading, -8)
+            BackButton(action: { showChangesWillBeLostAlert = true })
         } else {
             EmptyView()
         }

--- a/Sources/OctopusUI/Profile/CurrentUser/Summary/CurrentUserProfileSummaryView.swift
+++ b/Sources/OctopusUI/Profile/CurrentUser/Summary/CurrentUserProfileSummaryView.swift
@@ -153,10 +153,17 @@ struct CurrentUserProfileSummaryView: View {
     private var trailingBarItem: some View {
         Button(action: { navigator.push(.settingsList) }) {
             Image(systemName: "ellipsis")
-                .padding(.vertical)
-                .padding(.leading)
+                .modify {
+                    if #available(iOS 26.0, *) {
+                        $0
+                    } else {
+                        $0.padding(.vertical)
+                        .padding(.leading)
+                    }
+                }
                 .font(theme.fonts.navBarItem)
         }
+        .buttonStyle(.plain)
     }
 }
 
@@ -175,6 +182,13 @@ private struct ContentView<PostsView: View, NotificationsView: View>: View {
     var body: some View {
         if let profile {
             VStack(spacing: 0) {
+                // Disable nav bar opacity on iOS 26 to have the same behavior as before.
+                // TODO: See with product team if we need to keep it.
+                if #available(iOS 26.0, *) {
+                    Color.white.opacity(0.0001)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 1)
+                }
                 ProfileContentView(profile: profile,
                                    zoomableImageInfo: $zoomableImageInfo,
                                    hasInitialNotSeenNotifications: hasInitialNotSeenNotifications,

--- a/Sources/OctopusUI/Profile/OtherUsers/Summary/ProfileSummaryView.swift
+++ b/Sources/OctopusUI/Profile/OtherUsers/Summary/ProfileSummaryView.swift
@@ -153,8 +153,15 @@ struct ProfileSummaryView: View {
             }, label: {
                 VStack {
                     Image(systemName: "ellipsis")
-                        .padding(.vertical)
-                        .padding(.leading)
+                        .modify {
+                            if #available(iOS 26.0, *) {
+                                $0
+                            } else {
+                                $0.padding(.vertical)
+                                .padding(.leading)
+                            }
+
+                        }
                         .font(theme.fonts.navBarItem)
                 }.frame(width: 32, height: 32)
             })
@@ -181,6 +188,13 @@ private struct ContentView<PostsView: View>: View {
     var body: some View {
         if let profile {
             VStack(spacing: 0) {
+                // Disable nav bar opacity on iOS 26 to have the same behavior as before.
+                // TODO: See with product team if we need to keep it.
+                if #available(iOS 26.0, *) {
+                    Color.white.opacity(0.0001)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 1)
+                }
                 ProfileContentView(profile: profile, zoomableImageInfo: $zoomableImageInfo, refresh: refresh) {
                     postsView
                 }

--- a/Sources/OctopusUI/RootFeeds/RootFeedsView.swift
+++ b/Sources/OctopusUI/RootFeeds/RootFeedsView.swift
@@ -13,7 +13,7 @@ struct RootFeedsView: View {
     @Compat.StateObject private var viewModel: RootFeedsViewModel
 
     @State private var showRootFeedPicker = false
-    @State private var rootFeedPickerDetentHeight: CGFloat = 0
+    @State private var rootFeedPickerDetentHeight: CGFloat = 80
 
     @State private var displayError = false
     @State private var displayableError: DisplayableString?
@@ -94,11 +94,13 @@ struct RootFeedsView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 28)
+                .fixedSize()
         case let .text(title):
             Text(title.text)
                 .font(theme.fonts.title2)
                 .fontWeight(.semibold)
                 .foregroundColor(navBarPrimaryColor ? theme.colors.onPrimary : theme.colors.gray900)
+                .fixedSize()
         }
     }
 
@@ -111,6 +113,13 @@ struct RootFeedsView: View {
                 Text("Common.Close", bundle: .module)
                     .font(theme.fonts.navBarItem)
                     .foregroundColor(navBarPrimaryColor ? theme.colors.onPrimary : theme.colors.primary)
+            }
+            .modify {
+                if #available(iOS 26.0, *), navBarPrimaryColor {
+                    $0.glassEffect(.regular.tint(theme.colors.primary))
+                } else {
+                    $0
+                }
             }
         }
     }

--- a/Sources/OctopusUI/Router/ConnectionRouter.swift
+++ b/Sources/OctopusUI/Router/ConnectionRouter.swift
@@ -34,6 +34,7 @@ struct ConnectionRouter: ViewModifier {
                 NavigationView {
                     CreateProfileView(octopus: octopus)
                         .environment(\.dismissModal, $openCreateProfile)
+                        .presentationBackground(Color(.systemBackground))
                 }
                 .navigationBarHidden(true)
                 .accentColor(theme.colors.primary)

--- a/Sources/OctopusUI/Utils/Compat/Toolbar.swift
+++ b/Sources/OctopusUI/Utils/Compat/Toolbar.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © 2025 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func toolbar<LeadingView: View, TrailingView: View>(
+        leading: LeadingView, trailing: TrailingView,
+        leadingSharedBackgroundVisibility: Compat.Visibility = .automatic,
+        trailingSharedBackgroundVisibility: Compat.Visibility = .automatic
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            self.toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    leading
+                }
+                .sharedBackgroundVisibility(leadingSharedBackgroundVisibility.usableValue)
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    trailing
+                }
+                .sharedBackgroundVisibility(trailingSharedBackgroundVisibility.usableValue)
+            }
+        } else {
+            self.navigationBarItems(leading: leading, trailing: trailing)
+        }
+    }
+}

--- a/Sources/OctopusUI/Utils/View+PresentationBackground.swift
+++ b/Sources/OctopusUI/Utils/View+PresentationBackground.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © 2025 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+    /// Apply a safe area inset to this view.
+    /// When the keyboard is displayed, remove the inset
+    /// - Parameter bottomSafeAreaInset: the bottom safe area to set
+    @_disfavoredOverload
+    func presentationBackground(_ color: Color) -> some View {
+        self
+            .modify {
+                if #available(iOS 16.4, *) {
+                    $0.presentationBackground(color)
+                } else {
+                    $0
+                }
+            }
+    }
+}

--- a/Sources/OctopusUI/Utils/View+ZoomableImageContainer.swift
+++ b/Sources/OctopusUI/Utils/View+ZoomableImageContainer.swift
@@ -59,13 +59,19 @@ struct ZoomableImageContainer<LeadingBarItem: View, TrailingBarItem: View>: View
                 }
             }
         }
-        .navigationBarItems(leading: leadingBarItem, trailing: trailingBarItem)
+        .toolbar(
+            leading: leadingBarItem, trailing: trailingBarItem,
+            leadingSharedBackgroundVisibility: .hidden,
+            trailingSharedBackgroundVisibility: usableZoomableImageInfo != nil ? .hidden : .automatic)
         .navigationBarTitle(
             usableZoomableImageInfo == nil ? defaultNavigationBarTitle : Text(verbatim: ""),
             displayMode: .inline)
         .navigationBarBackButtonHidden(defaultNavigationBarBackButtonHidden || usableZoomableImageInfo != nil)
         .modify {
-            if #available(iOS 16.0, *), defaultNavigationBarPrimaryColor {
+            if #available(iOS 26.0, *), !defaultNavigationBarPrimaryColor {
+                $0
+                    .toolbarBackground(.hidden, for: .navigationBar)
+            } else if #available(iOS 16.0, *), defaultNavigationBarPrimaryColor {
                 $0
                     .toolbarBackground(theme.colors.primary, for: .navigationBar)
                     .toolbarBackground(zoomableImageInfo == nil ? .visible : .hidden, for: .navigationBar)
@@ -94,7 +100,14 @@ struct ZoomableImageContainer<LeadingBarItem: View, TrailingBarItem: View>: View
             }) {
                 Image(systemName: "xmark")
                     .font(theme.fonts.navBarItem.weight(.semibold))
-                    .padding(.leading)
+                    .modify {
+                        if #available(iOS 26.0, *) {
+                            $0
+                        } else {
+                            $0.padding(.leading)
+                        }
+
+                    }
                     .foregroundColor(theme.colors.primary)
                     .colorScheme(.dark)
             }


### PR DESCRIPTION
Improved the UI when build with Xcode 26 and running on iOS 26. Main changes:
- Add .presentationBackground(Color(.systemBackground)) on every view that is presented otherwise their background is transparent
- Changed the back button to remove the padding on iOS 26
- Changed the navigation bar to use a more recent one to correctly place and configure the items

Please note that this version can only be build using Xcode 26. If you are still using Xcode 16, please use the v1.5.3.