### PR TITLE
Release v1.6.1

### DIFF
--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.6.0
+APP_VERSION = 1.6.1
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsView.swift
+++ b/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsView.swift
@@ -20,11 +20,11 @@ struct ForceOctopusABTestsView: View {
             Text("The following switch will permanently override the internal cohort attribution for the current user.")
                 .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Toggle(isOn: $canAccessCommunity) {
+            Toggle(isOn: $viewModel.hasCommunityAccess) {
                 Text("Can access the community")
             }
 
-            Button(action: { viewModel.overrideCommunityAccess(enabled: canAccessCommunity) }) {
+            Button(action: { viewModel.overrideCommunityAccess(enabled: viewModel.hasCommunityAccess) }) {
                 Text("Override cohort attribution")
                     .padding()
             }.background(

--- a/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsViewModel.swift
+++ b/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsViewModel.swift
@@ -10,6 +10,7 @@ import Octopus
 /// View model of ForceOctopusABTestsView
 class ForceOctopusABTestsViewModel: ObservableObject {
     @Published private(set) var octopus: OctopusSDK?
+    @Published var hasCommunityAccess = false
     @Published var error: Error?
 
     private var storage = [AnyCancellable]()
@@ -20,6 +21,7 @@ class ForceOctopusABTestsViewModel: ObservableObject {
         octopusSDKProvider.$octopus
             .sink { [unowned self] in
                 octopus = $0
+                hasCommunityAccess = octopus?.hasAccessToCommunity ?? false
             }.store(in: &storage)
     }
 

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Config/User/UserCommunityAccessSyncStore.swift
+++ b/Sources/OctopusCore/Config/User/UserCommunityAccessSyncStore.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © 2025 Octopus Community. All rights reserved.
+//
+
+import Foundation
+
+/// A store that can be read synchronously to get the value of `hasAccessToCommunity`.
+class UserCommunityAccessSyncStore {
+    private let userDefaults = UserDefaults.standard
+
+    private let hasAccessToCommunityKey = "OctopusSDK.UserConfig.hasAccessToCommunityKey"
+    private(set) var hasAccessToCommunity: Bool?
+
+    init() {
+        hasAccessToCommunity = userDefaults.object(forKey: hasAccessToCommunityKey) as? Bool
+    }
+
+    func set(hasAccessToCommunity: Bool) {
+        userDefaults.set(hasAccessToCommunity, forKey: hasAccessToCommunityKey)
+    }
+}

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.6.0"
+public let version: String = "1.6.1"

--- a/Tests/OctopusTests/APITests.swift
+++ b/Tests/OctopusTests/APITests.swift
@@ -74,7 +74,7 @@ class APITests {
         _ = OctopusSDK.isAnOctopusNotification(notification: UNNotification(coder: NSCoder())!) != false
     }
 
-    @Test func testHasCommunityAccess() async throws {
+    @Test func testTrackCommunityAccess() async throws {
         let octopus = try OctopusSDK(apiKey: "API_KEY")
         octopus.track(hasAccessToCommunity: true)
     }
@@ -83,6 +83,13 @@ class APITests {
         let octopus = try OctopusSDK(apiKey: "API_KEY")
         try await octopus.overrideCommunityAccess(true)
     }
+
+    @Test func testHasCommunityAccess() async throws {
+        let octopus = try OctopusSDK(apiKey: "API_KEY")
+        _ = octopus.hasAccessToCommunity
+        _ = octopus.$hasAccessToCommunity
+    }
+
 
     @Test func testTrackCustomEvent() async throws {
         let octopus = try OctopusSDK(apiKey: "API_KEY")


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
- `OctopusSDK.hasAccessToCommunity` has been added. This publisher indicates whether the current user has access to the community features.

### Deprecated APIs
Nothing

# Internal changes:
Nothing