### PR TITLE
Release v1.6.2

### DIFF
--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.6.1
+APP_VERSION = 1.6.2
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/Sample/OctopusSample/Model/AppUserManager.swift
+++ b/Sample/OctopusSample/Model/AppUserManager.swift
@@ -18,9 +18,11 @@ class AppUserManager {
     private var storage = [AnyCancellable]()
 
     private init() {
-        appUserStore.$user.sink { [unowned self] in
-            appUser = $0
-        }.store(in: &storage)
+        appUserStore.$user
+            .removeDuplicates()
+            .sink { [unowned self] in
+                appUser = $0
+            }.store(in: &storage)
 
         // As soon as the user changes, inform the SDK
         Publishers.CombineLatest3(

--- a/Sample/OctopusSample/UI/AppAccount/AccountViewModel.swift
+++ b/Sample/OctopusSample/UI/AppAccount/AccountViewModel.swift
@@ -29,6 +29,7 @@ class AccountViewModel: ObservableObject {
             }.store(in: &storage)
 
         $appUser
+            .removeDuplicates()
             .sink {
                 AppUserManager.instance.set(appUser: $0)
             }.store(in: &storage)

--- a/Sample/OctopusSample/UI/OctopusUIView.swift
+++ b/Sample/OctopusSample/UI/OctopusUIView.swift
@@ -20,6 +20,8 @@ struct OctopusUIView: View {
     @State private var displayAppUserLogin = false
     @State private var displayEditAppUserProfile = false
 
+    @State private var isDisplayed = false
+
     init(
         octopus: OctopusSDK,
         bottomSafeAreaInset: CGFloat = 0,
@@ -51,6 +53,7 @@ struct OctopusUIView: View {
             AppEditUserScreen()
         }
         .onReceive(OctopusSDKProvider.instance.$clientLoginRequired) {
+            guard isDisplayed else { return }
             guard $0 else { return }
             displayAppUserLogin = true
         }
@@ -59,12 +62,19 @@ struct OctopusUIView: View {
             OctopusSDKProvider.instance.clientLoginRequired = false
         }
         .onReceive(OctopusSDKProvider.instance.$clientModifyUserAsked) {
+            guard isDisplayed else { return }
             guard $0 else { return }
             displayEditAppUserProfile = true
         }
         .onValueChanged(of: displayEditAppUserProfile) {
             guard !$0 else { return }
             OctopusSDKProvider.instance.clientModifyUserAsked = false
+        }
+        .onAppear {
+            isDisplayed = true
+        }
+        .onDisappear {
+            isDisplayed = false
         }
     }
 }

--- a/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsViewModel.swift
+++ b/Sample/OctopusSample/UI/Scenarios/ForceOctopusABTests/ForceOctopusABTestsViewModel.swift
@@ -23,15 +23,31 @@ class ForceOctopusABTestsViewModel: ObservableObject {
                 octopus = $0
                 hasCommunityAccess = octopus?.hasAccessToCommunity ?? false
             }.store(in: &storage)
+
+        octopusSDKProvider.$octopus
+            .map {
+                guard let octopus = $0 else {
+                    return Just<Bool>(false).eraseToAnyPublisher()
+                }
+                return octopus.$hasAccessToCommunity.eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .sink { [unowned self] in
+                hasCommunityAccess = $0
+            }.store(in: &storage)
     }
 
     func overrideCommunityAccess(enabled: Bool) {
         Task {
-            do {
-                try await octopus?.overrideCommunityAccess(enabled)
-            } catch {
-                self.error = error
-            }
+            await overrideCommunityAccess(enabled: enabled)
+        }
+    }
+
+    private func overrideCommunityAccess(enabled: Bool) async {
+        do {
+            try await octopus?.overrideCommunityAccess(enabled)
+        } catch {
+            self.error = error
         }
     }
 }

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Config/User/UserConfig.swift
+++ b/Sources/OctopusCore/Config/User/UserConfig.swift
@@ -6,7 +6,7 @@ import Foundation
 import OctopusGrpcModels
 
 /// The configuration of the current community (identified by the API key).
-public struct UserConfig {
+public struct UserConfig: Equatable {
     /// Whether the user can access the community
     public let canAccessCommunity: Bool
     public let accessDeniedMessage: String?

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.6.1"
+public let version: String = "1.6.2"

--- a/Sources/OctopusUI/Home/OctopusHomeScreenViewModel.swift
+++ b/Sources/OctopusUI/Home/OctopusHomeScreenViewModel.swift
@@ -29,9 +29,11 @@ class OctopusHomeScreenViewModel: ObservableObject {
         ).sink { [unowned self] profile, userConfig, isLocked in
             guard !isLocked else { return }
             guard userConfig?.canAccessCommunity ?? true else {
+                displayOnboarding = false
                 displayCommunityAccessDenied = true
                 return
             }
+            displayCommunityAccessDenied = false
             if let profile, !profile.hasSeenOnboarding {
                 displayOnboarding = true
             } else {

--- a/Sources/OctopusUI/Loggers/Loggers.swift
+++ b/Sources/OctopusUI/Loggers/Loggers.swift
@@ -22,6 +22,8 @@ extension Logger {
     static let profile = Logger(subsystem: subsystem, category: "Profile")
     /// Logs that are related to the notifications
     static let notifs = Logger(subsystem: subsystem, category: "Notifications")
+    /// Logs that are related to the config
+    static let config = Logger(subsystem: subsystem, category: "Config")
     /// Logs that are related to general stuff
     static let general = Logger(subsystem: subsystem, category: "General")
 }

--- a/Sources/OctopusUI/Onboarding/OnboardingViewModel.swift
+++ b/Sources/OctopusUI/Onboarding/OnboardingViewModel.swift
@@ -32,6 +32,7 @@ class OnboardingViewModel: ObservableObject {
             .profilePublisher
             .sink { [unowned self] profile in
                 guard let profile, profile.hasSeenOnboarding, profile.hasAcceptedCgu else { return }
+                isLoading = false
                 dismiss = true
             }.store(in: &storage)
     }

--- a/Sources/OctopusUI/Router/ConnectionRouter.swift
+++ b/Sources/OctopusUI/Router/ConnectionRouter.swift
@@ -65,9 +65,8 @@ struct ConnectionRouter: ViewModifier {
                     Text(error, bundle: .module)
                 })
             .onReceive(viewModel.$ssoError) { error in
-                guard let error else { return }
                 displayableSSOError = error
-                displaySSOError = true
+                displaySSOError = error != nil
             }
             .onReceive(viewModel.$displayLoadConfigError) { display in
                 guard display else { return }
@@ -82,6 +81,7 @@ struct ConnectionRouter: ViewModifier {
                 case let .error(error):
                     displayableSSOError = error
                     displaySSOError = true
+                    viewModel.linkClientUserToOctopusUser()
                 case .none: break
                 }
             }
@@ -119,6 +119,7 @@ class ConnectionRouterViewModel: ObservableObject {
     private func linkClientUserToOctopusUser() async {
         do {
             try await octopus.core.connectionRepository.linkClientUserToOctopusUser()
+            ssoError = nil
         } catch {
             switch error {
             case let .detailedErrors(errors):

--- a/Tests/OctopusCoreTests/ProfileTests.swift
+++ b/Tests/OctopusCoreTests/ProfileTests.swift
@@ -24,6 +24,7 @@ class ProfileTests: XCTestCase {
     override func setUp() {
         let injector = Injector()
         injector.register { _ in try! ModelCoreDataStack(inRam: true) }
+        injector.register { _ in try! ConfigCoreDataStack(inRam: true) }
         injector.register { CurrentUserProfileDatabase(injector: $0) }
         injector.register { PublicProfileDatabase(injector: $0) }
         injector.registerMocks(.remoteClient, .securedStorage, .networkMonitor, .magicLinkMonitor,
@@ -38,6 +39,9 @@ class ProfileTests: XCTestCase {
         injector.register { PostsDatabase(injector: $0) }
         injector.register { FeedItemInfosDatabase(injector: $0) }
         injector.register { ClientUserProvider(connectionMode: .octopus(deepLink: nil), injector: $0) }
+        injector.register { UserConfigDatabase(injector: $0) }
+        injector.register { CommunityConfigDatabase(injector: $0) }
+        injector.register { ConfigRepositoryDefault(injector: $0) }
 
         profileRepository = ProfileRepositoryDefault(appManagedFields: [], injector: injector)
         mockUserService = (injector.getInjected(identifiedBy: Injected.remoteClient)

--- a/Tests/OctopusCoreTests/SSOConnectionTests.swift
+++ b/Tests/OctopusCoreTests/SSOConnectionTests.swift
@@ -22,6 +22,7 @@ class SSOConnectionTests: XCTestCase {
         let connectionMode = ConnectionMode.sso(.init(appManagedFields: [], loginRequired: { }, modifyUser: { _ in }))
         injector = Injector()
         injector.register { _ in try! ModelCoreDataStack(inRam: true) }
+        injector.register { _ in try! ConfigCoreDataStack(inRam: true) }
         injector.register { CurrentUserProfileDatabase(injector: $0) }
         injector.register { ProfileRepositoryDefault(appManagedFields: [], injector: $0) }
         injector.registerMocks(.remoteClient, .securedStorage, .networkMonitor,
@@ -39,6 +40,9 @@ class SSOConnectionTests: XCTestCase {
         injector.register { FeedItemInfosDatabase(injector: $0) }
         injector.register { ClientUserProvider(connectionMode: connectionMode, injector: $0) }
         injector.register { ClientUserProfileDatabase(injector: $0) }
+        injector.register { UserConfigDatabase(injector: $0) }
+        injector.register { CommunityConfigDatabase(injector: $0) }
+        injector.register { ConfigRepositoryDefault(injector: $0) }
 
         mockUserService = (injector.getInjected(identifiedBy: Injected.remoteClient)
             .userService as! MockUserService)


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
Nothing

### Deprecated APIs
Nothing

# Internal changes:
- The call to `disconnectUser` now logs out the community profile (and a new guest profile is created)
- Fixes some weird behaviors during connection when the user changes
- Fixes connection problems when the guest user is in the AB test that does not have access to the community and the `connectUser` function is called
- Fetch the community access information when the community access denied screen is displayed
- Display the community access denied screen with a higher priority than the onboarding screen