### PR TITLE
Release v1.10.2

### DIFF
--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.10.1
+APP_VERSION = 1.10.2
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.10.1'
+  VERSION = '1.10.2'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.10.1"
+public let version: String = "1.10.2"

--- a/Sources/OctopusUI/UIElements/ZoomableImageView.swift
+++ b/Sources/OctopusUI/UIElements/ZoomableImageView.swift
@@ -272,7 +272,8 @@ struct ZoomableImageView: View {
     private func startDeceleration() {
         isDecelerating = true
 
-        var currentVelocity = dragVelocity
+        // Safe: currentVelocity is only read and mutated on the main queue (via DispatchQueue.main.async)
+        nonisolated(unsafe) var currentVelocity = dragVelocity
         let decelerationFactor: CGFloat = 0.95
 
         stopDeceleration()


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
Nothing

### Deprecated APIs
Nothing

### Other
Nothing

# Internal changes:
- Fix Swift concurrency build error in ZoomableImageView on Xcode 26.4