### PR TITLE
Release v1.12.1

### DIFF
--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.12.0
+APP_VERSION = 1.12.1
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.12.0'
+  VERSION = '1.12.1'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.12.0"
+public let version: String = "1.12.1"

--- a/Sources/OctopusUI/Home/OctopusHomeScreen.swift
+++ b/Sources/OctopusUI/Home/OctopusHomeScreen.swift
@@ -170,12 +170,14 @@ public struct OctopusHomeScreen: View {
             octopus.core.trackingRepository.octopusUISessionStarted()
             displayScreenAfterNotificationTapped(notificationUserInfo: notificationUserInfo)
             if !viewModel.displayCommunityAccessDenied {
+                gamificationRulesViewManager.setHomeScreenVisible(true)
                 gamificationRulesViewManager.incrementViewCountIfNeeded()
             }
         }
         .onDisappear {
             octopus.core.toastsRepository.resetDisplayedToasts()
             octopus.core.trackingRepository.octopusUISessionEnded()
+            gamificationRulesViewManager.setHomeScreenVisible(false)
         }
         .onValueChanged(of: notificationUserInfo != nil) { hasValue in
             guard hasValue else { return }

--- a/Sources/OctopusUI/ObservableUIObjects/GamificationRulesViewManager.swift
+++ b/Sources/OctopusUI/ObservableUIObjects/GamificationRulesViewManager.swift
@@ -21,6 +21,11 @@ final class GamificationRulesViewManager: ObservableObject {
     private var viewCount: Int!
 
     private var gamificationEnabled: Bool { gamificationConfig != nil }
+    /// Whether the home screen is currently on screen. The rules sheet must only ever be presented
+    /// while the home screen is visible: otherwise it can be triggered (e.g. by the config arriving)
+    /// while the SDK is preloaded in a background SwiftUI `TabView` tab, presenting the sheet over —
+    /// and corrupting the layout of — the host app's currently visible screen.
+    private var isHomeScreenVisible = false
     private var storage = [AnyCancellable]()
 
     /// Designated init. Accepts the gamification-config publisher directly so previews/tests can
@@ -51,6 +56,16 @@ final class GamificationRulesViewManager: ObservableObject {
         rulesDisplayedOnce = true
     }
 
+    /// Called by the home screen when its visibility changes (`onAppear` / `onDisappear`).
+    /// Becoming visible re-evaluates the conditions so a sheet whose conditions were met while
+    /// the screen was off screen is presented as soon as the user actually opens the community.
+    func setHomeScreenVisible(_ visible: Bool) {
+        isHomeScreenVisible = visible
+        if visible {
+            updateShouldDisplayGamificationRules()
+        }
+    }
+
     func incrementViewCountIfNeeded() {
         if gamificationEnabled {
             viewCount += 1
@@ -59,7 +74,7 @@ final class GamificationRulesViewManager: ObservableObject {
     }
 
     private func updateShouldDisplayGamificationRules() {
-        if viewCount >= 3, !rulesDisplayedOnce, gamificationEnabled {
+        if viewCount >= 3, !rulesDisplayedOnce, gamificationEnabled, isHomeScreenVisible {
             shouldDisplayGamificationRules = true
         }
     }

--- a/Tests/OctopusUITests/GamificationRulesViewManagerTests.swift
+++ b/Tests/OctopusUITests/GamificationRulesViewManagerTests.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import Testing
+import Combine
+@testable import OctopusUI
+@testable import OctopusCore
+
+@Suite
+@MainActor
+class GamificationRulesViewManagerTests {
+
+    private static let viewCountKey = "OctopusSDK.UI.GamificationRulesViewManager.viewCount"
+    private static let rulesDisplayedOnceKey = "OctopusSDK.UI.GamificationRulesViewManager.rulesDisplayedOnce"
+
+    private func resetDefaults() {
+        UserDefaults.standard.removeObject(forKey: Self.viewCountKey)
+        UserDefaults.standard.removeObject(forKey: Self.rulesDisplayedOnceKey)
+    }
+
+    private func makeManager(gamificationEnabled: Bool) -> GamificationRulesViewManager {
+        let config: GamificationConfig? = gamificationEnabled
+            ? GamificationConfig(pointsName: "Points", abbrevPointSingular: "pt", abbrevPointPlural: "pts",
+                                 pointsByAction: [:], gamificationLevels: [])
+            : nil
+        return GamificationRulesViewManager(
+            gamificationConfigPublisher: Just(config).eraseToAnyPublisher())
+    }
+
+    /// The reported bug: the rules sheet was triggered even when the home screen was not on screen
+    /// (e.g. preloaded in a background SwiftUI TabView tab), leaking onto the host app.
+    @Test func doesNotTriggerWhenHomeScreenNotVisible_evenWhenAllOtherConditionsAreMet() {
+        resetDefaults()
+        let manager = makeManager(gamificationEnabled: true)
+
+        // Reach the view-count threshold without ever marking the home screen as visible.
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+
+        #expect(manager.shouldDisplayGamificationRules == false)
+    }
+
+    @Test func triggersWhenHomeScreenVisibleAndConditionsMet() {
+        resetDefaults()
+        let manager = makeManager(gamificationEnabled: true)
+        manager.setHomeScreenVisible(true)
+
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+
+        #expect(manager.shouldDisplayGamificationRules == true)
+    }
+
+    @Test func becomingVisibleAfterConditionsMet_triggersTheSheet() {
+        resetDefaults()
+        let manager = makeManager(gamificationEnabled: true)
+
+        // Conditions reached while not visible -> must stay hidden.
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+        #expect(manager.shouldDisplayGamificationRules == false)
+
+        // Becoming visible re-evaluates and now triggers.
+        manager.setHomeScreenVisible(true)
+        #expect(manager.shouldDisplayGamificationRules == true)
+    }
+
+    @Test func doesNotTriggerWhenGamificationDisabled() {
+        resetDefaults()
+        let manager = makeManager(gamificationEnabled: false)
+        manager.setHomeScreenVisible(true)
+
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+        manager.incrementViewCountIfNeeded()
+
+        #expect(manager.shouldDisplayGamificationRules == false)
+    }
+}


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
Nothing

### Deprecated APIs
Nothing

### Other
Nothing

# Internal changes:
- Fixed the gamification rules sheet being presented over (and corrupting the layout of) the host app's currently visible screen when the SDK is preloaded in a background SwiftUI TabView tab. The sheet is now only presented while the Octopus home screen is actually visible.
