### PR TITLE
Release v1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ You can easily integrate all of these features with our Android and iOS SDKs.
 ## How to use
 If you want to use OctopusSDK, follow our [official documentation](https://octopus-documentation.pages.dev/) for integration.
 
+### Hosting `OctopusHomeScreen` inside a modal
+By default `OctopusHomeScreen` uses a legacy `NavigationView`. When the screen is presented inside a modal that
+reparents its hosting controller — a SwiftUI `.sheet` / `.fullScreenCover`, or a Flutter / React Native modal route —
+that legacy navigation can silently drop in-app pushes (e.g. tapping a post no longer opens its detail).
+
+If you host the SDK that way, opt into a `NavigationStack` (iOS 16+, with a legacy fallback below iOS 16):
+
+```swift
+OctopusHomeScreen(octopus: octopus, navigationMode: .navigationStack)
+```
+
+Pushed into the navigation stack normally (no modal), the default `.automatic` mode is the right choice.
+
 ## How to run the tests
 We provide tests in the Swift Package.
 To run them:

--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.12.1
+APP_VERSION = 1.12.2
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/Sample/OctopusSample/Model/NavigationModeManager.swift
+++ b/Sample/OctopusSample/Model/NavigationModeManager.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import Combine
+import OctopusUI
+
+/// Internal-demo-only preference: which `OctopusNavigationMode` the sample uses when it presents the
+/// Octopus UI inside a modal. Lets QA flip between `.automatic` (legacy `NavigationView`) and
+/// `.navigationStack` (real `NavigationStack` on iOS 16+) to compare behavior on the same build.
+enum SampleNavigationMode: String, CaseIterable, Identifiable {
+    case automatic
+    case navigationStack
+
+    var id: String { rawValue }
+
+    var displayableString: String {
+        switch self {
+        case .automatic: return "Automatic"
+        case .navigationStack: return "NavigationStack"
+        }
+    }
+
+    var octopusNavigationMode: OctopusNavigationMode {
+        switch self {
+        case .automatic: return .automatic
+        case .navigationStack: return .navigationStack
+        }
+    }
+}
+
+/// Persists the chosen `SampleNavigationMode` in UserDefaults so every modal entry point of the sample
+/// reads the same value. For internal testing only.
+class NavigationModeManager: ObservableObject {
+    static let instance = NavigationModeManager()
+
+    private let storageKey = "sampleNavigationMode"
+
+    @Published var mode: SampleNavigationMode {
+        didSet {
+            UserDefaults.standard.set(mode.rawValue, forKey: storageKey)
+        }
+    }
+
+    private init() {
+        let raw = UserDefaults.standard.string(forKey: storageKey)
+        mode = raw.flatMap(SampleNavigationMode.init(rawValue:)) ?? .automatic
+    }
+}

--- a/Sample/OctopusSample/UI/OctopusUIView.swift
+++ b/Sample/OctopusSample/UI/OctopusUIView.swift
@@ -14,6 +14,7 @@ struct OctopusUIView: View {
     let mainFeedNavBarTitle: OctopusMainFeedTitle?
     let mainFeedColoredNavBar: Bool
     let initialScreen: OctopusInitialScreen
+    let navigationMode: OctopusNavigationMode
 
     @Binding var octopusNotificationUserInfo: [AnyHashable: Any]?
 
@@ -30,12 +31,14 @@ struct OctopusUIView: View {
         mainFeedNavBarTitle: OctopusMainFeedTitle? = nil,
         mainFeedColoredNavBar: Bool = false,
         initialScreen: OctopusInitialScreen = .mainFeed,
+        navigationMode: OctopusNavigationMode = .automatic,
         octopusNotificationUserInfo: Binding<[AnyHashable: Any]?> = .constant(nil)) {
         self.octopus = octopus
         self.bottomSafeAreaInset = bottomSafeAreaInset
         self.mainFeedNavBarTitle = mainFeedNavBarTitle
         self.mainFeedColoredNavBar = mainFeedColoredNavBar
         self.initialScreen = initialScreen
+        self.navigationMode = navigationMode
         self._octopusNotificationUserInfo = octopusNotificationUserInfo
     }
 
@@ -46,6 +49,7 @@ struct OctopusUIView: View {
             mainFeedNavBarTitle: mainFeedNavBarTitle,
             mainFeedColoredNavBar: mainFeedColoredNavBar,
             initialScreen: initialScreen,
+            navigationMode: navigationMode,
             notificationUserInfo: $octopusNotificationUserInfo
         )
         .fullScreenCover(isPresented: $displayAppUserLogin) {

--- a/Sample/OctopusSample/UI/Scenarios/Modal/ModalOctopusView.swift
+++ b/Sample/OctopusSample/UI/Scenarios/Modal/ModalOctopusView.swift
@@ -10,6 +10,7 @@ import OctopusUI
 /// A view that displays the Octopus UI in a full screen modal
 struct ModalOctopusView: View {
     @StateObjectCompat private var viewModel = OctopusAuthSDKViewModel()
+    @ObservedObject private var navigationModeManager = NavigationModeManager.instance
     @Binding var openOctopusAsModal: Bool
 
     @Environment(\.sizeCategory) var sizeCategory // make it recompute the theme when the size category changes
@@ -27,6 +28,10 @@ struct ModalOctopusView: View {
 
                 Text("This is your app's content")
                     .font(.headline)
+
+                if DefaultValuesProvider.internalDemoMode {
+                    navigationModePicker
+                }
 
                 Button(action: { openOctopusAsModal = true }) {
                     HStack {
@@ -65,6 +70,7 @@ struct ModalOctopusView: View {
         .fullScreenCover(isPresented: $openOctopusAsModal) {
             OctopusUIView(
                 octopus: viewModel.octopus,
+                navigationMode: navigationModeManager.mode.octopusNavigationMode,
                 octopusNotificationUserInfo: $octopusNotificationUserInfo
             )
             // only for used for internal purpose, you can ignore this for the easiest way to use Octopus
@@ -80,6 +86,22 @@ struct ModalOctopusView: View {
             octopusNotificationUserInfo = $0
         }
         .hostAppFooter()
+    }
+
+    // Internal-demo control: pick the navigation mode used when the Octopus UI is opened in this modal.
+    // Flip it then tap "Open the Octopus Community" to compare `.automatic` vs `.navigationStack`.
+    private var navigationModePicker: some View {
+        VStack(spacing: 4) {
+            Text("Navigation mode (internal)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Picker("", selection: $navigationModeManager.mode) {
+                ForEach(SampleNavigationMode.allCases) { mode in
+                    Text(mode.displayableString).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
     }
 
     @ViewBuilder

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.12.1'
+  VERSION = '1.12.2'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.12.1"
+public let version: String = "1.12.2"

--- a/Sources/OctopusUI/Atoms/NavBarLeadingActionButton.swift
+++ b/Sources/OctopusUI/Atoms/NavBarLeadingActionButton.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+/// Renders the host-driven leading nav-bar item (`OctopusNavBarLeadingAction`) using the SDK's native
+/// `CloseButton` / `BackButton`, so it matches the styling of the SDK's own nav-bar items.
+///
+/// Screens with an unsaved-changes guard can pass a custom `onTap` (e.g. one that shows a confirmation
+/// alert first); by default the action's own closure is used.
+struct NavBarLeadingActionButton: View {
+    private let action: OctopusNavBarLeadingAction
+    private let onTap: () -> Void
+
+    init(_ action: OctopusNavBarLeadingAction, onTap: (() -> Void)? = nil) {
+        self.action = action
+        self.onTap = onTap ?? action.onTap
+    }
+
+    var body: some View {
+        switch action {
+        case .close:
+            CloseButton(action: onTap)
+        case .back:
+            BackButton(action: onTap)
+        }
+    }
+}

--- a/Sources/OctopusUI/CommunityAccessDenied/CommunityAccessDeniedView.swift
+++ b/Sources/OctopusUI/CommunityAccessDenied/CommunityAccessDeniedView.swift
@@ -12,16 +12,20 @@ struct CommunityAccessDeniedView: View {
 
     @Compat.StateObject private var viewModel: CommunityAccessDeniedViewModel
     private let canClose: Bool
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
-    init(octopus: OctopusSDK, canClose: Bool) {
+    init(octopus: OctopusSDK, canClose: Bool, navBarLeadingAction: OctopusNavBarLeadingAction? = nil) {
         _viewModel = Compat.StateObject(wrappedValue: CommunityAccessDeniedViewModel(octopus: octopus))
         self.canClose = canClose
+        self.navBarLeadingAction = navBarLeadingAction
     }
 
     var body: some View {
         ContentView(accessDeniedMessage: viewModel.accessDeniedMessage)
             .modify {
-                if canClose {
+                if let navBarLeadingAction {
+                    $0.navigationBarItems(leading: NavBarLeadingActionButton(navBarLeadingAction))
+                } else if canClose {
                     $0.navigationBarItems(
                         leading:
                             Button(action: { presentationMode.wrappedValue.dismiss() }) {

--- a/Sources/OctopusUI/Flows/Main/MainFlowNavigationStack.swift
+++ b/Sources/OctopusUI/Flows/Main/MainFlowNavigationStack.swift
@@ -12,18 +12,31 @@ struct MainFlowNavigationStack<RootView: View>: View {
 
     let octopus: OctopusSDK
     let bottomSafeAreaInset: CGFloat
+    let navigationMode: OctopusNavigationMode
     @Compat.StateObject private var mainFlowPath: MainFlowPath
     @ViewBuilder let rootView: RootView
 
     @State private var bottomInset: CGFloat
 
     init(octopus: OctopusSDK, mainFlowPath: MainFlowPath, bottomSafeAreaInset: CGFloat = 0,
+         navigationMode: OctopusNavigationMode = .automatic,
          @ViewBuilder _ rootView: () -> RootView) {
         self.octopus = octopus
         _mainFlowPath = Compat.StateObject(wrappedValue: mainFlowPath)
         self.bottomSafeAreaInset = bottomSafeAreaInset
+        self.navigationMode = navigationMode
         self.rootView = rootView()
         self._bottomInset = .init(initialValue: bottomSafeAreaInset)
+    }
+
+    /// Maps the public navigation mode onto the `NavigationBackport` policy.
+    /// `.automatic` keeps the legacy `NavigationView` (see the `TODO Djavan` note below), while
+    /// `.navigationStack` opts into a real `NavigationStack` on iOS 16+ (legacy fallback below).
+    private var navigationStackPolicy: UseNavigationStackPolicy {
+        switch navigationMode {
+        case .automatic: return .never
+        case .navigationStack: return .whenAvailable
+        }
     }
 
     var body: some View {
@@ -98,6 +111,8 @@ struct MainFlowNavigationStack<RootView: View>: View {
         }
         // TODO Djavan remove this as it forces to use navigationView instead of navigationStack. It has been set
         // because of a bug impacting the CreatePostView that was re-created when put in background.
-        .nbUseNavigationStack(.never)
+        // The policy can now be overridden via `OctopusHomeScreen`'s `navigationMode` (`.navigationStack`)
+        // for hosts that present the SDK in a modal, where the legacy NavigationView drops pushes.
+        .nbUseNavigationStack(navigationStackPolicy)
     }
 }

--- a/Sources/OctopusUI/Groups/Detail/GroupDetailView.swift
+++ b/Sources/OctopusUI/Groups/Detail/GroupDetailView.swift
@@ -19,17 +19,20 @@ struct GroupDetailView: View {
 
     private let mainFlowPath: MainFlowPath
     private let canClose: Bool
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
     @State private var zoomableImageInfo: ZoomableImageInfo?
 
     init(octopus: OctopusSDK, groupId: String, mainFlowPath: MainFlowPath,
          translationStore: ContentTranslationPreferenceStore,
-         canClose: Bool = false, origin: GroupDetailNavigationOrigin = .sdk) {
+         canClose: Bool = false, origin: GroupDetailNavigationOrigin = .sdk,
+         navBarLeadingAction: OctopusNavBarLeadingAction? = nil) {
         _viewModel = Compat.StateObject(wrappedValue: GroupDetailViewModel(
             octopus: octopus, groupId: groupId, mainFlowPath: mainFlowPath,
             translationStore: translationStore, origin: origin))
         self.mainFlowPath = mainFlowPath
         self.canClose = canClose
+        self.navBarLeadingAction = navBarLeadingAction
     }
 
     var body: some View {
@@ -135,7 +138,9 @@ struct GroupDetailView: View {
 
     @ViewBuilder
     private func leadingBarItem(group: GroupDetail?) -> some View {
-        if canClose {
+        if let navBarLeadingAction {
+            NavBarLeadingActionButton(navBarLeadingAction)
+        } else if canClose {
             CloseButton(action: { presentationMode.wrappedValue.dismiss() })
         } else {
             EmptyView()

--- a/Sources/OctopusUI/Home/OctopusHomeScreen.swift
+++ b/Sources/OctopusUI/Home/OctopusHomeScreen.swift
@@ -16,6 +16,12 @@ import UserNotifications
 /// content.
 ///
 /// This SwiftUI view contains a NavigationView, hence it should be not embedded in another Navigation object.
+///
+/// ⚠️ Modal hosting: by default `OctopusHomeScreen` uses a legacy `NavigationView`, which can silently drop
+/// in-app navigation pushes when the screen is presented inside a modal that reparents its hosting controller
+/// (SwiftUI `.sheet` / `.fullScreenCover`, or a Flutter / React Native modal route). If you host the SDK that
+/// way, pass `navigationMode: .navigationStack` to use a `NavigationStack` (iOS 16+) instead. See
+/// ``OctopusNavigationMode``.
 public struct OctopusHomeScreen: View {
 
     @Environment(\.octopusTheme) private var theme
@@ -28,6 +34,8 @@ public struct OctopusHomeScreen: View {
     private let mainFeedNavBarTitle: OctopusMainFeedTitle?
     private let mainFeedColoredNavBar: Bool
     private let initialScreen: OctopusInitialScreen
+    private let navigationMode: OctopusNavigationMode
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
     @Compat.StateObject private var viewModel: OctopusHomeScreenViewModel
     @Compat.StateObject private var translationStore: ContentTranslationPreferenceStore
@@ -55,6 +63,18 @@ public struct OctopusHomeScreen: View {
     ///                             If false, default nav bar color will be used. Default is false.
     ///    - initialScreen: the initial screen to display. Default is `.mainFeed` which shows the feed with the feed
     ///                     selector. Use `.post` or `.group` to open a specific post or group in bridge mode.
+    ///    - navigationMode: which navigation container the screen uses internally. Default is `.automatic`
+    ///                      (legacy `NavigationView`). Pass `.navigationStack` when hosting `OctopusHomeScreen`
+    ///                      inside a modal presentation (SwiftUI `.sheet` / `.fullScreenCover`, or a Flutter /
+    ///                      React Native modal route), where the legacy navigation can silently drop in-app
+    ///                      pushes. See `OctopusNavigationMode`.
+    ///    - navBarLeadingAction: an optional host-driven leading nav-bar item displayed on the root screen (the one
+    ///                           selected by `initialScreen`). Use it when you host `OctopusHomeScreen` somewhere the
+    ///                           SDK cannot dismiss itself (pushed on your own navigation stack, or mounted by a
+    ///                           Flutter / React Native plugin): the SDK's built-in close button only appears when the
+    ///                           view is presented natively (`.sheet` / `.fullScreenCover`). Pass `.close(onTap:)` or
+    ///                           `.back(onTap:)` to show the corresponding item and be told when it is tapped — the
+    ///                           closure runs instead of dismissing a SwiftUI presentation. Default is nil.
     ///    - notificationUserInfo: a binding on the `userInfo` dictionary of a push notification (i.e. the
     ///                            `request.content.userInfo` of a `UNNotification`, or the raw payload received
     ///                            from cross-platform push plugins like Firebase Messaging).
@@ -74,6 +94,8 @@ public struct OctopusHomeScreen: View {
                 mainFeedNavBarTitle: OctopusMainFeedTitle? = nil,
                 mainFeedColoredNavBar: Bool = false,
                 initialScreen: OctopusInitialScreen = .mainFeed,
+                navigationMode: OctopusNavigationMode = .automatic,
+                navBarLeadingAction: OctopusNavBarLeadingAction? = nil,
                 notificationUserInfo: Binding<[AnyHashable: Any]?> = .constant(nil)) {
         _viewModel = Compat.StateObject(wrappedValue: OctopusHomeScreenViewModel(octopus: octopus))
         _translationStore = Compat.StateObject(wrappedValue: ContentTranslationPreferenceStore(
@@ -93,15 +115,20 @@ public struct OctopusHomeScreen: View {
             self.mainFeedColoredNavBar = false
         }
         self.initialScreen = initialScreen
+        self.navigationMode = navigationMode
+        self.navBarLeadingAction = navBarLeadingAction
         self._notificationUserInfo = notificationUserInfo
     }
 
     public var body: some View {
-        MainFlowNavigationStack(octopus: octopus, mainFlowPath: viewModel.mainFlowPath, bottomSafeAreaInset: bottomSafeAreaInset) {
+        MainFlowNavigationStack(octopus: octopus, mainFlowPath: viewModel.mainFlowPath,
+                                bottomSafeAreaInset: bottomSafeAreaInset, navigationMode: navigationMode) {
             if #available(iOS 14.0, *) {
                 Group {
                     if viewModel.displayCommunityAccessDenied {
-                        CommunityAccessDeniedView(octopus: octopus, canClose: presentationMode.wrappedValue.isPresented)
+                        CommunityAccessDeniedView(octopus: octopus,
+                                                  canClose: presentationMode.wrappedValue.isPresented,
+                                                  navBarLeadingAction: navBarLeadingAction)
                     } else {
                         Group {
                             switch initialScreen {
@@ -110,7 +137,8 @@ public struct OctopusHomeScreen: View {
                                     octopus: octopus,
                                     mainFlowPath: viewModel.mainFlowPath,
                                     navBarTitle: mainFeedNavBarTitle,
-                                    coloredNavBar: mainFeedColoredNavBar)
+                                    coloredNavBar: mainFeedColoredNavBar,
+                                    navBarLeadingAction: navBarLeadingAction)
                             case let .post(info):
                                 PostDetailView(
                                     octopus: octopus, mainFlowPath: viewModel.mainFlowPath,
@@ -121,14 +149,16 @@ public struct OctopusHomeScreen: View {
                                     scrollToMostRecentComment: false,
                                     origin: .clientApp,
                                     hasFeaturedComment: false,
-                                    canClose: presentationMode.wrappedValue.isPresented)
+                                    canClose: presentationMode.wrappedValue.isPresented,
+                                    navBarLeadingAction: navBarLeadingAction)
                             case let .group(info):
                                 GroupDetailView(
                                     octopus: octopus, groupId: info.groupId,
                                     mainFlowPath: viewModel.mainFlowPath,
                                     translationStore: translationStore,
                                     canClose: presentationMode.wrappedValue.isPresented,
-                                    origin: .clientApp)
+                                    origin: .clientApp,
+                                    navBarLeadingAction: navBarLeadingAction)
                             case let .createPost(info):
                                 CreatePostView(
                                     octopus: octopus,
@@ -138,7 +168,8 @@ public struct OctopusHomeScreen: View {
                                     defaultImage: info.prefilledPost?.image,
                                     cta: info.prefilledPost?.cta.map { WritableCTA(url: $0.url, label: $0.label) },
                                     creationSource: info.prefilledPost == nil ? .user : .prefilledFromClient,
-                                    canClose: presentationMode.wrappedValue.isPresented)
+                                    canClose: presentationMode.wrappedValue.isPresented,
+                                    navBarLeadingAction: navBarLeadingAction)
                             }
                         }
                     }

--- a/Sources/OctopusUI/Home/OctopusNavBarLeadingAction.swift
+++ b/Sources/OctopusUI/Home/OctopusNavBarLeadingAction.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Foundation
+
+/// A leading navigation-bar item driven by the host app, displayed on whatever Octopus screen is at the
+/// root of the Octopus navigation stack (the screen selected via `OctopusHomeScreen`'s `initialScreen`:
+/// the main feed, or a bridge post / group, …).
+///
+/// Use this when you host `OctopusHomeScreen` somewhere the SDK has no SwiftUI presentation context to
+/// dismiss — e.g. pushed onto your own `UINavigationController` stack, or mounted by a Flutter / React
+/// Native plugin inside a `UIHostingController`. In those setups the SDK's built-in close button never
+/// appears (it only shows when the view is presented natively via `.sheet` / `.fullScreenCover`), so the
+/// host needs to provide its own dismiss affordance and be told when it is tapped.
+///
+/// The tap fires the closure you provide instead of dismissing a SwiftUI presentation — it is up to the
+/// host to pop its route / dismiss its container.
+public enum OctopusNavBarLeadingAction {
+    /// A close button (the SDK's "close" icon), e.g. for a modally-presented host container.
+    case close(onTap: () -> Void)
+    /// A back button (a back chevron), e.g. for a host navigation route.
+    case back(onTap: () -> Void)
+
+    /// The closure to run when the item is tapped.
+    var onTap: () -> Void {
+        switch self {
+        case let .close(onTap): return onTap
+        case let .back(onTap): return onTap
+        }
+    }
+}

--- a/Sources/OctopusUI/Home/OctopusNavigationMode.swift
+++ b/Sources/OctopusUI/Home/OctopusNavigationMode.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Foundation
+
+/// Controls which navigation container `OctopusHomeScreen` uses internally.
+///
+/// `OctopusHomeScreen` drives its sub-navigation (opening a post, a group, a profile, …) through a
+/// navigation path. The container backing that path can either be the legacy `NavigationView` or a
+/// `NavigationStack`. They don't behave identically when the screen is hosted inside a **modal
+/// presentation**: see ``automatic`` and ``navigationStack`` for details.
+public enum OctopusNavigationMode {
+    /// The SDK picks the navigation container. It currently uses a legacy `NavigationView` (chosen to
+    /// work around an internal `CreatePostView` lifecycle issue); this default may change in a future
+    /// version.
+    ///
+    /// ⚠️ Known limitation: when `OctopusHomeScreen` is hosted inside a **modal presentation** that
+    /// reparents its hosting controller (SwiftUI `.sheet` / `.fullScreenCover`, or a Flutter / React
+    /// Native modal route), the legacy `NavigationView` can silently drop programmatic pushes — e.g.
+    /// tapping a post no longer opens its detail. In that hosting context, use ``navigationStack``.
+    case automatic
+
+    /// Forces a `NavigationStack` when available (iOS 16+, with a legacy `NavigationView` fallback below
+    /// iOS 16). `NavigationStack` keeps its navigation path working across hosting-controller
+    /// reparenting, so this is the recommended mode when hosting `OctopusHomeScreen` inside a modal
+    /// presentation (`.sheet` / `.fullScreenCover`, Flutter / React Native modal route, …).
+    case navigationStack
+}

--- a/Sources/OctopusUI/MainRootFeed/MainRootFeedView.swift
+++ b/Sources/OctopusUI/MainRootFeed/MainRootFeedView.swift
@@ -18,6 +18,7 @@ struct MainRootFeedView: View {
     private let mainFlowPath: MainFlowPath
     private let navBarTitle: OctopusMainFeedTitle?
     private let coloredNavBar: Bool
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
     @State private var zoomableImageInfo: ZoomableImageInfo?
 
@@ -25,11 +26,13 @@ struct MainRootFeedView: View {
          mainFlowPath: MainFlowPath,
          navBarTitle: OctopusMainFeedTitle?,
          coloredNavBar: Bool,
+         navBarLeadingAction: OctopusNavBarLeadingAction? = nil
     ) {
         _viewModel = Compat.StateObject(wrappedValue: MainRootFeedViewModel(octopus: octopus))
         self.mainFlowPath = mainFlowPath
         self.navBarTitle = navBarTitle
         self.coloredNavBar = coloredNavBar
+        self.navBarLeadingAction = navBarLeadingAction
     }
 
     var body: some View {
@@ -64,7 +67,11 @@ struct MainRootFeedView: View {
 
     @ViewBuilder
     private var leadingBarItem: some View {
-        if let navBarTitle, navBarTitle.placement == .leading {
+        if let navBarLeadingAction {
+            // The host provided a leading item (close/back). It takes the leading slot; the feed title is
+            // relocated to the centered slot (see `centeredBarItem`) so it is not lost.
+            NavBarLeadingActionButton(navBarLeadingAction)
+        } else if let navBarTitle, navBarTitle.placement == .leading {
             switch navBarTitle.content {
             case .logo:
                 if theme.assets.logoIsCustomized {
@@ -107,6 +114,40 @@ struct MainRootFeedView: View {
         return false
     }
 
+    /// The feed title rendered in the centered slot when a host `navBarLeadingAction` occupies the leading
+    /// slot. Mirrors the leading title resolution (logo if customized, else the provided text, else the
+    /// default "Community") but with the inline nav-bar title styling used in the centered slot.
+    @ViewBuilder
+    private var relocatedCenteredTitle: some View {
+        switch navBarTitle?.content {
+        case .logo:
+            if theme.assets.logoIsCustomized {
+                Image(uiImage: theme.assets.logo)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 33)
+                    .fixedSize()
+                    .accessibilityHidden(true)
+            } else {
+                defaultCenteredTitle
+            }
+        case let .text(title):
+            Text(title.text)
+                .inlineNavigationBarTitleFont()
+                .foregroundColor(coloredNavBar ? theme.colors.onPrimary : theme.colors.gray900)
+                .fixedSize()
+        case nil:
+            defaultCenteredTitle
+        }
+    }
+
+    private var defaultCenteredTitle: some View {
+        Text("Community.Default.Title", bundle: .module)
+            .inlineNavigationBarTitleFont()
+            .foregroundColor(coloredNavBar ? theme.colors.onPrimary : theme.colors.gray900)
+            .fixedSize()
+    }
+
     @ViewBuilder
     private var trailingBarItem: some View {
         if presentationMode.wrappedValue.isPresented {
@@ -133,7 +174,10 @@ struct MainRootFeedView: View {
 
     @ViewBuilder
     private var centeredBarItem: some View {
-        if let navBarTitle, navBarTitle.placement == .center {
+        if navBarLeadingAction != nil {
+            // The leading slot is taken by the host item, so the feed title is shown centered here.
+            relocatedCenteredTitle
+        } else if let navBarTitle, navBarTitle.placement == .center {
             switch navBarTitle.content {
             case .logo:
                 if theme.assets.logoIsCustomized {
@@ -161,7 +205,10 @@ struct MainRootFeedView: View {
     }
 
     private var centeredItemVisibility: Compat.Visibility {
-        if let navBarTitle, navBarTitle.placement == .center {
+        if navBarLeadingAction != nil {
+            // Title relocated to center (see `relocatedCenteredTitle`): always resolves to visible content.
+            return .visible
+        } else if let navBarTitle, navBarTitle.placement == .center {
             switch navBarTitle.content {
             case .logo:
                 if theme.assets.logoIsCustomized {

--- a/Sources/OctopusUI/Posts/Create/CreatePostView.swift
+++ b/Sources/OctopusUI/Posts/Create/CreatePostView.swift
@@ -18,6 +18,7 @@ struct CreatePostView: View {
     @State private var showChangesWillBeLostAlert = false
 
     private let canClose: Bool
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
     init(octopus: OctopusSDK,
          withPoll: Bool,
@@ -26,7 +27,8 @@ struct CreatePostView: View {
          defaultImage: Data? = nil,
          cta: WritableCTA? = nil,
          creationSource: PostsRepository.CreationSource = .user,
-         canClose: Bool = false) {
+         canClose: Bool = false,
+         navBarLeadingAction: OctopusNavBarLeadingAction? = nil) {
         _viewModel = Compat.StateObject(wrappedValue: CreatePostViewModel(
             octopus: octopus,
             withPoll: withPoll,
@@ -36,6 +38,17 @@ struct CreatePostView: View {
             cta: cta,
             creationSource: creationSource))
         self.canClose = canClose
+        self.navBarLeadingAction = navBarLeadingAction
+    }
+
+    /// Leaves the composer: runs the host leading action when provided, otherwise dismisses the SwiftUI
+    /// presentation (which pops it when pushed, or dismisses it when presented modally).
+    private func leaveScreen() {
+        if let navBarLeadingAction {
+            navBarLeadingAction.onTap()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
     }
 
     var body: some View {
@@ -54,7 +67,7 @@ struct CreatePostView: View {
                     createPoll: viewModel.createPoll)
         .connectionRouter(octopus: viewModel.octopus, noConnectedReplacementAction: $viewModel.authenticationAction)
         .navigationBarTitle(Text("Post.Create.Title", bundle: .module), displayMode: .inline)
-        .navigationBarBackButtonHidden(viewModel.hasChanges || canClose)
+        .navigationBarBackButtonHidden(viewModel.hasChanges || canClose || navBarLeadingAction != nil)
         .toolbar(leading: leadingBarItem, trailing: postButton,
                  trailingSharedBackgroundVisibility: .hidden)
         .fullScreenCover(isPresented: $showTopicPicker) {
@@ -72,7 +85,7 @@ struct CreatePostView: View {
             isPresented: $showChangesWillBeLostAlert,
             cancelLabel: "Common.No",
             destructiveLabel: "Common.Yes",
-            action: { presentationMode.wrappedValue.dismiss() })
+            action: { leaveScreen() })
         .emitScreenDisplayed(.createPost, trackingApi: trackingApi)
         .onReceive(viewModel.$dismiss) { shouldDismiss in
             guard shouldDismiss else { return }
@@ -82,7 +95,15 @@ struct CreatePostView: View {
 
     @ViewBuilder
     private var leadingBarItem: some View {
-        if canClose && viewModel.hasChanges {
+        if let navBarLeadingAction {
+            NavBarLeadingActionButton(navBarLeadingAction, onTap: {
+                if viewModel.hasChanges {
+                    showChangesWillBeLostAlert = true
+                } else {
+                    navBarLeadingAction.onTap()
+                }
+            })
+        } else if canClose && viewModel.hasChanges {
             CloseButton(action: { showChangesWillBeLostAlert = true })
         } else if canClose && !viewModel.hasChanges {
             CloseButton(action: { presentationMode.wrappedValue.dismiss() })

--- a/Sources/OctopusUI/Posts/Detail/PostDetailView.swift
+++ b/Sources/OctopusUI/Posts/Detail/PostDetailView.swift
@@ -32,6 +32,7 @@ struct PostDetailView: View {
 
     private let canClose: Bool
     private let mainFlowPath: MainFlowPath
+    private let navBarLeadingAction: OctopusNavBarLeadingAction?
 
     init(octopus: OctopusSDK, mainFlowPath: MainFlowPath, translationStore: ContentTranslationPreferenceStore,
          postUuid: String,
@@ -40,7 +41,8 @@ struct PostDetailView: View {
          scrollToMostRecentComment: Bool = false,
          origin: PostDetailNavigationOrigin,
          hasFeaturedComment: Bool,
-         canClose: Bool = false) {
+         canClose: Bool = false,
+         navBarLeadingAction: OctopusNavBarLeadingAction? = nil) {
         _viewModel = Compat.StateObject(wrappedValue: PostDetailViewModel(
             octopus: octopus, mainFlowPath: mainFlowPath, translationStore: translationStore,
             postUuid: postUuid,
@@ -51,6 +53,19 @@ struct PostDetailView: View {
             hasFeaturedComment: hasFeaturedComment))
         self.canClose = canClose
         self.mainFlowPath = mainFlowPath
+        self.navBarLeadingAction = navBarLeadingAction
+    }
+
+    /// Leaves the post detail: runs the host leading action when provided, otherwise dismisses a native
+    /// presentation (`canClose`) or pops the SDK navigation stack.
+    private func leaveScreen() {
+        if let navBarLeadingAction {
+            navBarLeadingAction.onTap()
+        } else if canClose {
+            presentationMode.wrappedValue.dismiss()
+        } else {
+            navigator.pop()
+        }
     }
 
     var body: some View {
@@ -136,13 +151,7 @@ struct PostDetailView: View {
             isPresented: $showChangesWillBeLostAlert,
             cancelLabel: "Common.No",
             destructiveLabel: "Common.Yes",
-            action: {
-                if canClose {
-                    presentationMode.wrappedValue.dismiss()
-                } else {
-                    navigator.pop()
-                }
-            })
+            action: { leaveScreen() })
         .destructiveConfirmationAlert(
             "Block.Profile.Alert.Title",
             isPresented: $displayWillBlockAlert,
@@ -163,26 +172,14 @@ struct PostDetailView: View {
                 $0.alert(
                     Text("Post.Delete.Done", bundle: .module),
                     isPresented: $displayPostDeletedAlert, actions: {
-                        Button(action: {
-                            if canClose {
-                                presentationMode.wrappedValue.dismiss()
-                            } else {
-                                navigator.pop()
-                            }
-                        }) {
+                        Button(action: { leaveScreen() }) {
                             Text("Common.Ok", bundle: .module)
                         }
                     })
             } else {
                 $0.alert(isPresented: $displayPostDeletedAlert) {
                     Alert(title: Text("Post.Delete.Done", bundle: .module),
-                          dismissButton: .default(Text("Common.Ok", bundle: .module), action: {
-                        if canClose {
-                            presentationMode.wrappedValue.dismiss()
-                        } else {
-                            navigator.pop()
-                        }
-                    }))
+                          dismissButton: .default(Text("Common.Ok", bundle: .module), action: { leaveScreen() }))
                 }
             }
         }
@@ -202,26 +199,14 @@ struct PostDetailView: View {
                 $0.alert(
                     Text("Content.Detail.NotAvailable", bundle: .module),
                     isPresented: $viewModel.postDisappeared, actions: {
-                        Button(action: {
-                            if canClose {
-                                presentationMode.wrappedValue.dismiss()
-                            } else {
-                                navigator.pop()
-                            }
-                        }) {
+                        Button(action: { leaveScreen() }) {
                             Text("Common.Ok", bundle: .module)
                         }
                     })
             } else {
                 $0.alert(isPresented: $viewModel.postDisappeared) {
                     Alert(title: Text("Content.Detail.NotAvailable", bundle: .module),
-                          dismissButton: .default(Text("Common.Ok", bundle: .module), action: {
-                        if canClose {
-                            presentationMode.wrappedValue.dismiss()
-                        } else {
-                            navigator.pop()
-                        }
-                    }))
+                          dismissButton: .default(Text("Common.Ok", bundle: .module), action: { leaveScreen() }))
                 }
             }
         }
@@ -229,7 +214,15 @@ struct PostDetailView: View {
 
     @ViewBuilder
     private var leadingBarItem: some View {
-        if canClose {
+        if let navBarLeadingAction {
+            NavBarLeadingActionButton(navBarLeadingAction, onTap: {
+                if commentHasChanges {
+                    showChangesWillBeLostAlert = true
+                } else {
+                    navBarLeadingAction.onTap()
+                }
+            })
+        } else if canClose {
             CloseButton(action: {
                 if commentHasChanges {
                     showChangesWillBeLostAlert = true

--- a/Tests/OctopusUITests/APITests.swift
+++ b/Tests/OctopusUITests/APITests.swift
@@ -21,6 +21,15 @@ class APITests {
         _ = OctopusHomeScreen(octopus: octopusSdk, initialScreen: .mainFeed)
         _ = OctopusHomeScreen(octopus: octopusSdk, initialScreen: .post(.init(postId: "POST_ID")))
         _ = OctopusHomeScreen(octopus: octopusSdk, initialScreen: .group(.init(groupId: "GROUP_ID")))
+        _ = OctopusHomeScreen(octopus: octopusSdk, navigationMode: .automatic)
+        _ = OctopusHomeScreen(octopus: octopusSdk, navigationMode: .navigationStack)
+        _ = OctopusHomeScreen(octopus: octopusSdk, navBarLeadingAction: .close(onTap: {}))
+        _ = OctopusHomeScreen(octopus: octopusSdk, navBarLeadingAction: .back(onTap: {}))
+        _ = OctopusHomeScreen(octopus: octopusSdk, navBarLeadingAction: nil)
+        _ = OctopusHomeScreen(octopus: octopusSdk, initialScreen: .post(.init(postId: "P")),
+                              navBarLeadingAction: .back(onTap: {}))
+        _ = OctopusHomeScreen(octopus: octopusSdk, navigationMode: .navigationStack,
+                              navBarLeadingAction: .close(onTap: {}))
         _ = OctopusHomeScreen(octopus: octopusSdk, notificationUserInfo: .constant(nil))
         _ = OctopusHomeScreen(octopus: octopusSdk, notificationUserInfo: .constant(["k": "v"]))
     }

--- a/Tests/OctopusUITests/OctopusNavBarLeadingActionTests.swift
+++ b/Tests/OctopusUITests/OctopusNavBarLeadingActionTests.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © 2026 Octopus Community. All rights reserved.
+//
+
+import Testing
+@testable import OctopusUI
+
+/// Tests for the pure `onTap` accessor of `OctopusNavBarLeadingAction`, used by the root screens to wire
+/// the host-provided callback onto the leading nav-bar button (regardless of close vs back).
+struct OctopusNavBarLeadingActionTests {
+
+    @Test func closeForwardsItsClosure() {
+        var tapped = false
+        OctopusNavBarLeadingAction.close(onTap: { tapped = true }).onTap()
+        #expect(tapped == true)
+    }
+
+    @Test func backForwardsItsClosure() {
+        var tapped = false
+        OctopusNavBarLeadingAction.back(onTap: { tapped = true }).onTap()
+        #expect(tapped == true)
+    }
+}


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
- `OctopusHomeScreen` now accepts a `navigationMode` parameter (`OctopusNavigationMode`: `.automatic` | `.navigationStack`). Pass `.navigationStack` when presenting the community inside a modal (`.sheet` / `.fullScreenCover`, or a Flutter / React Native modal route) so in-app navigation pushes (e.g. opening a post) keep working. Default `.automatic` preserves the previous behavior.
- `OctopusHomeScreen` now accepts a `navBarLeadingAction` parameter (`OctopusNavBarLeadingAction`: `.close(onTap:)` | `.back(onTap:)`). Use it to display a host-driven close/back button on the root screen when hosting the community outside a native SwiftUI presentation (pushed on your own `UINavigationController`, or mounted by a Flutter / React Native plugin); the tap runs your closure instead of dismissing a SwiftUI presentation.

### Deprecated APIs
Nothing

### Other
Nothing

# Internal changes:
Nothing