### PR TITLE
Release v1.12.4

### DIFF
--- a/Sample/OctopusSample.xcodeproj/project.pbxproj
+++ b/Sample/OctopusSample.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = OctopusSample/OctopusSample-Release.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "OctopusSample/OctopusSample-Release.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/Sample/OctopusSample/Config/config.xcconfig
+++ b/Sample/OctopusSample/Config/config.xcconfig
@@ -1,7 +1,7 @@
 #include "secrets.xcconfig"
 
 // Version of the app
-APP_VERSION = 1.12.3
+APP_VERSION = 1.12.4
 // Default build number. Overridden by build system
 BUILD_NUMBER = 0
 

--- a/SharedPodSpecConfig.rb
+++ b/SharedPodSpecConfig.rb
@@ -1,5 +1,5 @@
 module SharedPodSpecConfig
-  VERSION = '1.12.3'
+  VERSION = '1.12.4'
   GITHUB_PAGE = 'https://github.com/Octopus-Community/octopus-sdk-swift'
   SOURCE = { :git => "#{GITHUB_PAGE}.git", :tag => "v#{VERSION}" }
   LICENSE = { :file => 'LICENSE.md' }

--- a/Sources/OctopusCore/Version.swift
+++ b/Sources/OctopusCore/Version.swift
@@ -3,4 +3,4 @@
 //
 
 /// Version of the SDK
-public let version: String = "1.12.3"
+public let version: String = "1.12.4"

--- a/Sources/OctopusUI/Utils/Compat/ScrollView.swift
+++ b/Sources/OctopusUI/Utils/Compat/ScrollView.swift
@@ -38,7 +38,7 @@ extension Compat {
             self.preventScrollIfContentFits = preventScrollIfContentFits
             self.canScrollToExtremities = canScrollToExtremities
             if let refreshAction {
-                self._refreshAction = State(initialValue: {
+                self._refreshAction = State(initialValue: { @Sendable in
                     let refreshTask = Task { await refreshAction() }
                     let durationTask = Task {
                         try? await Task.sleep(nanoseconds: UInt64(minTime * 1_000_000_000))


### PR DESCRIPTION
# API Changes:
## Breaking changes:
Nothing

## Non-breaking changes:
### New APIs
Nothing

### Deprecated APIs
Nothing

### Other
Nothing

# Internal changes:
- Fixed compilation under Xcode 27 / Swift 6.4. Swift 6.4 no longer infers a closure passed to a SwiftUI `@State` initializer as `@Sendable`, which broke the build of the SDK's internal scroll-view compatibility helper. The closure is now explicitly annotated `@Sendable`. No behavioral change; the SDK still builds on Xcode 26 / Swift 6.3.
